### PR TITLE
Chore: exclude healthcheck url from loggingMiddleware

### DIFF
--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -2,6 +2,11 @@ import { RequestHandler } from "express";
 import logger from "../logger";
 
 const loggerMiddleware:RequestHandler = (req, res, next) => {
+    if (req.path === "/health") {
+        next();
+        return;
+    }
+
     const {
         method, url, params, query, body,
     } = req;


### PR DESCRIPTION
LB health check로 인해 로그가 너무 많이 쌓임